### PR TITLE
Made 'on sale' filter toggle-able

### DIFF
--- a/Poe-On-Sale.user.js
+++ b/Poe-On-Sale.user.js
@@ -12,14 +12,16 @@ var purchaseLink = document.getElementsByClassName("purchaseLink")[1];
 
 var a = document.createElement("a");
 a.setAttribute("class", "button-text red shopBuyMoreCoinsButton");
-a.innerHTML = "Find on Sale";
-
-//button.outerHTML = "<a class=\"button-text red shopBuyMoreCoinsButton\"> Find on Sale <\/a>";
+a.innerHTML = "On Sale Toggle";
 
 purchaseLink.appendChild(a);
 
 a.addEventListener ("click", function() {
-  var items = $('.shopItemBase');
-  var filtered = $(items).filter(function() { return $(this).find('.onSaleIcon').length == 0; });
-  $(filtered).remove();
+  $(this).prop('disabled', true);
+
+  $('.shopItemBase').filter(function() {
+    return $(this).find('.onSaleIcon').length == 0;
+  }).toggle();
+
+  $(this).prop('disabled', false);
 });


### PR DESCRIPTION
In it's current state, the filter action is not re-usable so the user has to refresh the page to go back to seeing all items.

This change makes the filter action a toggle and so items that are not on sale can be shown/hidden at will.